### PR TITLE
feat: reveal prompt on card click

### DIFF
--- a/components/PromptCard.tsx
+++ b/components/PromptCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CopyIcon } from './icons/CopyIcon';
 import { CheckIcon } from './icons/CheckIcon';
 
@@ -10,27 +10,35 @@ interface PromptCardProps {
 }
 
 export const PromptCard: React.FC<PromptCardProps> = ({ title, prompt, isCopied, onCopy }) => {
+  const [isFlipped, setIsFlipped] = useState(false);
+
   return (
     <div
-      className="bg-white border border-gray-200 rounded-md p-6 flex flex-col justify-between transition-all duration-300 hover:border-gray-300"
+      className="bg-white border border-gray-200 rounded-md p-6 flex flex-col justify-between transition-all duration-300 hover:border-gray-300 cursor-pointer"
+      onClick={() => setIsFlipped((prev) => !prev)}
     >
-      <div>
-        <h3 className="text-xl font-bold text-gray-900 mb-2">{title}</h3>
-        <p className="text-gray-600 text-base leading-relaxed">{prompt}</p>
-      </div>
-      <div className="mt-6 text-right">
-        <button
-          onClick={onCopy}
-          className={`inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-200 focus:outline-none border ${
-            isCopied
-              ? 'bg-gray-900 text-white border-gray-900 cursor-default'
-              : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50 hover:border-gray-300'
-          }`}
-        >
-          {isCopied ? <CheckIcon className="w-4 h-4" /> : <CopyIcon className="w-4 h-4" />}
-          {isCopied ? 'Скопировано!' : 'Копировать'}
-        </button>
-      </div>
+      <h3 className="text-xl font-bold text-gray-900 mb-2">{title}</h3>
+      {isFlipped && (
+        <>
+          <p className="text-gray-600 text-base leading-relaxed">{prompt}</p>
+          <div className="mt-6 text-right">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onCopy();
+              }}
+              className={`inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-200 focus:outline-none border ${
+                isCopied
+                  ? 'bg-gray-900 text-white border-gray-900 cursor-default'
+                  : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50 hover:border-gray-300'
+              }`}
+            >
+              {isCopied ? <CheckIcon className="w-4 h-4" /> : <CopyIcon className="w-4 h-4" />}
+              {isCopied ? 'Скопировано!' : 'Копировать'}
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/components/PromptCard.tsx
+++ b/components/PromptCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useLayoutEffect } from 'react';
 import { CopyIcon } from './icons/CopyIcon';
 import { CheckIcon } from './icons/CheckIcon';
 
@@ -11,16 +11,38 @@ interface PromptCardProps {
 
 export const PromptCard: React.FC<PromptCardProps> = ({ title, prompt, isCopied, onCopy }) => {
   const [isFlipped, setIsFlipped] = useState(false);
+  const backRef = useRef<HTMLDivElement>(null);
+  const [cardHeight, setCardHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    if (backRef.current) {
+      setCardHeight(backRef.current.offsetHeight);
+    }
+  }, [prompt]);
 
   return (
     <div
-      className="bg-white border border-gray-200 rounded-md p-6 flex flex-col justify-between transition-all duration-300 hover:border-gray-300 cursor-pointer"
+      className="relative cursor-pointer [perspective:1000px]"
+      style={{ height: cardHeight ? cardHeight : undefined }}
       onClick={() => setIsFlipped((prev) => !prev)}
     >
-      <h3 className="text-xl font-bold text-gray-900 mb-2">{title}</h3>
-      {isFlipped && (
-        <>
-          <p className="text-gray-600 text-base leading-relaxed">{prompt}</p>
+      <div
+        className={`absolute inset-0 transition-transform duration-500 [transform-style:preserve-3d] ${
+          isFlipped ? '[transform:rotateY(180deg)]' : ''
+        }`}
+      >
+        <div className="absolute inset-0 bg-white border border-gray-200 rounded-md p-6 flex flex-col justify-between [backface-visibility:hidden]">
+          <h3 className="text-xl font-bold text-gray-900 mb-2">{title}</h3>
+        </div>
+
+        <div
+          ref={backRef}
+          className="absolute inset-0 bg-white border border-gray-200 rounded-md p-6 flex flex-col justify-between [transform:rotateY(180deg)] [backface-visibility:hidden]"
+        >
+          <div>
+            <h3 className="text-xl font-bold text-gray-900 mb-2">{title}</h3>
+            <p className="text-gray-600 text-base leading-relaxed">{prompt}</p>
+          </div>
           <div className="mt-6 text-right">
             <button
               onClick={(e) => {
@@ -37,8 +59,8 @@ export const PromptCard: React.FC<PromptCardProps> = ({ title, prompt, isCopied,
               {isCopied ? 'Скопировано!' : 'Копировать'}
             </button>
           </div>
-        </>
-      )}
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide prompt contents until the user clicks a card
- show copy button and prompt after reveal, preventing accidental re-hide when copying

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68989ca98bc4832c934d36a2a7c36c85