### PR TITLE
feat: reveal prompt on card click

### DIFF
--- a/components/PromptCard.tsx
+++ b/components/PromptCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CopyIcon } from './icons/CopyIcon';
 import { CheckIcon } from './icons/CheckIcon';
 
@@ -10,27 +10,41 @@ interface PromptCardProps {
 }
 
 export const PromptCard: React.FC<PromptCardProps> = ({ title, prompt, isCopied, onCopy }) => {
+  const [showPrompt, setShowPrompt] = useState(false);
+
   return (
     <div
-      className="bg-white border border-gray-200 rounded-md p-6 flex flex-col justify-between transition-all duration-300 hover:border-gray-300"
+      onClick={() => setShowPrompt(!showPrompt)}
+      className="bg-white border border-gray-200 rounded-md p-6 flex flex-col justify-between transition-all duration-300 hover:border-gray-300 cursor-pointer"
     >
-      <div>
-        <h3 className="text-xl font-bold text-gray-900 mb-2">{title}</h3>
-        <p className="text-gray-600 text-base leading-relaxed">{prompt}</p>
-      </div>
-      <div className="mt-6 text-right">
-        <button
-          onClick={onCopy}
-          className={`inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-200 focus:outline-none border ${
-            isCopied
-              ? 'bg-gray-900 text-white border-gray-900 cursor-default'
-              : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50 hover:border-gray-300'
-          }`}
-        >
-          {isCopied ? <CheckIcon className="w-4 h-4" /> : <CopyIcon className="w-4 h-4" />}
-          {isCopied ? 'Скопировано!' : 'Копировать'}
-        </button>
-      </div>
+      {!showPrompt ? (
+        <div className="flex items-center justify-center h-full">
+          <h3 className="text-xl font-bold text-gray-900 text-center">{title}</h3>
+        </div>
+      ) : (
+        <>
+          <div>
+            <h3 className="text-xl font-bold text-gray-900 mb-2">{title}</h3>
+            <p className="text-gray-600 text-base leading-relaxed">{prompt}</p>
+          </div>
+          <div className="mt-6 text-right">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onCopy();
+              }}
+              className={`inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-200 focus:outline-none border ${
+                isCopied
+                  ? 'bg-gray-900 text-white border-gray-900 cursor-default'
+                  : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50 hover:border-gray-300'
+              }`}
+            >
+              {isCopied ? <CheckIcon className="w-4 h-4" /> : <CopyIcon className="w-4 h-4" />}
+              {isCopied ? 'Скопировано!' : 'Копировать'}
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
-};
+  };


### PR DESCRIPTION
## Summary
- show only card title initially
- reveal prompt and copy button when card is clicked

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68989ca98bc4832c934d36a2a7c36c85